### PR TITLE
Fix: 프로필 데이터 받아오기 친구 추가 거부 수정

### DIFF
--- a/src/pages/FriendPage.tsx
+++ b/src/pages/FriendPage.tsx
@@ -34,7 +34,7 @@ const FriendPage = () => {
 	}, []);
 
 	async function accept(friendId: number) {
-		await axios.post(`/friends`, {
+		await axios.post(`/friends/`, {
 			action: 'accept',
 			friend_id: friendId,
 			withCredentials: true,
@@ -50,7 +50,7 @@ const FriendPage = () => {
 		}
 	}
 	async function decline(friendId: number) {
-		await axios.post(`/friends`, {
+		await axios.post(`/friends/`, {
 			action: 'decline',
 			friend_id: friendId,
 			withCredentials: true,

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -16,8 +16,8 @@ interface Profile {
 const defaultProfile: Profile = {
 	id: 0,
 	profile_img: '/media/default_profile_img.jpg',
-	name: 'Unknown',
-	reliability: 0,
+	name: '머거유',
+	reliability: 50,
 	friend_count: 0,
 };
 
@@ -26,19 +26,14 @@ const ProfilePage = () => {
 
 	useEffect(() => {
 		async function fetchData() {
-			try {
-				const response = await axios.get('/profile');
-				setProfile(response.data.profile || defaultProfile);
-			} catch (error) {
-				console.log('에러');
-				setProfile(defaultProfile);
-			}
+			const response = await axios.get('/profile', { withCredentials: true });
+			setProfile(response.data || defaultProfile);
 		}
 		fetchData();
-	}, []);
+	}, [profile]);
 
 	if (!profile) {
-		return <p>Loading...</p>;
+		return <p>로딩 중</p>;
 	}
 
 	return (


### PR DESCRIPTION
## Fix: 프로필 데이터 받아오기 친구 추가 거부 수정

### PR을 한 이유 🎯

- 프로필 데이터 받아오고 친구 추가 거부 수정했음

### 이슈 번호 📎

- (해결하고자 하는 이슈의 이름과 해시태그 번호를 적어주세요. 예: `이슈명 #123`)

### 변경사항 🛠

- 프로필 데이터 받아오고 친구 추가 거부 수정했음

### 특이사항 📌

- 친구 추천에서 더하기는 안됨

### 테스트 결과 📝

-